### PR TITLE
Implement admin endpoints to get and verify users

### DIFF
--- a/backend/server/mongodb/actions/User.ts
+++ b/backend/server/mongodb/actions/User.ts
@@ -1,4 +1,4 @@
-import { Types } from "mongoose";
+import { Schema, Types } from "mongoose";
 import UserModel from "server/mongodb/models/User";
 import dbConnect from "server/utils/dbConnect";
 import { HandlerType, Role } from "src/utils/types";
@@ -54,4 +54,26 @@ export async function updateUser(
     birthday: birthday,
   });
   return user;
+}
+
+export async function verifyUser(userId: Types.ObjectId) {
+  await dbConnect();
+
+  const user = UserModel.findByIdAndUpdate(
+    userId,
+    { verifiedByAdmin: true },
+    { new: true }
+  );
+
+  return user;
+}
+
+export async function getUsers(pageSize: number, afterId?: Types.ObjectId) {
+  await dbConnect();
+
+  if (!afterId) {
+    return UserModel.find().limit(pageSize);
+  }
+
+  return UserModel.find({ _id: { $gt: afterId } }).limit(pageSize);
 }

--- a/backend/server/mongodb/models/User.ts
+++ b/backend/server/mongodb/models/User.ts
@@ -36,6 +36,11 @@ const UserSchema = new mongoose.Schema<User>({
     enum: Object.values(Role),
     default: [],
   },
+  verifiedByAdmin: {
+    type: Boolean,
+    required: true,
+    default: false,
+  },
 });
 
 const UserModel =

--- a/backend/src/pages/api/admin/user.ts
+++ b/backend/src/pages/api/admin/user.ts
@@ -1,1 +1,23 @@
-export {};
+import { Types } from "mongoose";
+import { getUsers } from "server/mongodb/actions/User";
+import APIWrapper from "server/utils/APIWrapper";
+import { Role } from "src/utils/types";
+
+export default APIWrapper({
+  GET: {
+    config: {
+      requireToken: true,
+      roles: [Role.NONPROFIT_ADMIN],
+    },
+    handler: async (req) => {
+      /* TODO: probably add a check to see if its a valid objectId,
+          and if not, indicate that in the response. */
+      const afterId: Types.ObjectId = req.body.afterId as Types.ObjectId;
+      const pageSize: number = req.body.pageSize as number;
+
+      const users = await getUsers(pageSize, afterId);
+
+      return users;
+    },
+  },
+});

--- a/backend/src/pages/api/admin/user/verified.ts
+++ b/backend/src/pages/api/admin/user/verified.ts
@@ -1,0 +1,20 @@
+import { Types } from "mongoose";
+import { getUsers, verifyUser } from "server/mongodb/actions/User";
+import APIWrapper from "server/utils/APIWrapper";
+import { Role } from "src/utils/types";
+
+export default APIWrapper({
+  PATCH: {
+    config: {
+      requireToken: true,
+      roles: [Role.NONPROFIT_ADMIN],
+    },
+    handler: async (req) => {
+      const userId: Types.ObjectId = req.body.userId as Types.ObjectId;
+
+      const users = verifyUser(userId);
+
+      return users;
+    },
+  },
+});

--- a/backend/src/utils/types.ts
+++ b/backend/src/utils/types.ts
@@ -23,6 +23,7 @@ export interface User {
   handlerType: HandlerType;
   birthday: Date;
   roles?: Array<Role>;
+  verifiedByAdmin: boolean;
 }
 
 export interface ServiceAnimal {

--- a/mobile/actions/User.ts
+++ b/mobile/actions/User.ts
@@ -1,12 +1,15 @@
 import { internalRequest } from "../utils/requests";
 import { HandlerType, HttpMethod, Role, User } from "../utils/types";
 import { urls } from "../utils/urls";
+import {Types} from "mongoose";
 
-const userUrl = urls.baseUrl + urls.api.user.user;
+const userUserUrl = urls.baseUrl + urls.api.user.user;
+const adminUserUrl = urls.baseUrl + urls.api.admin.user;
+const adminUserVerifiedUrl = urls.baseUrl + urls.api.admin.userVerified;
 
 export const userGetUserInfo = async () => {
   return internalRequest<User>({
-    url: userUrl,
+    url: userUserUrl,
     method: HttpMethod.GET,
     authRequired: true,
   });
@@ -22,7 +25,7 @@ export const userCreateUser = async (
   handlerType?: HandlerType
 ) => {
   return internalRequest<User>({
-    url: userUrl,
+    url: userUserUrl,
     method: HttpMethod.POST,
     body: {
       email,
@@ -44,7 +47,7 @@ export const userUpdateUser = async (
   handlerType?: HandlerType
 ) => {
   return internalRequest<User>({
-    url: userUrl,
+    url: userUserUrl,
     method: HttpMethod.PATCH,
     authRequired: true,
     body: {
@@ -56,3 +59,31 @@ export const userUpdateUser = async (
     },
   });
 };
+
+export const adminGetUsers = async (
+  pageSize: number,
+  afterId?: Types.ObjectId,
+) => {
+  return internalRequest<User[]>({
+    url: adminUserUrl,
+    method: HttpMethod.GET,
+    authRequired: true,
+    body: {
+      afterId,
+      pageSize,
+    },
+  });
+}
+
+export const adminVerifyUser = async (
+  userId: Types.ObjectId,
+) => {
+  return internalRequest<User[]>({
+    url: adminUserVerifiedUrl,
+    method: HttpMethod.PATCH,
+    authRequired: true,
+    body: {
+      userId,
+    },
+  });
+}

--- a/mobile/utils/types.ts
+++ b/mobile/utils/types.ts
@@ -37,6 +37,7 @@ export interface User {
   handlerType: HandlerType;
   birthday: Date;
   roles?: Array<Role>;
+  verifiedByAdmin: boolean;
 }
 
 export interface ServiceAnimal {

--- a/mobile/utils/urls.ts
+++ b/mobile/utils/urls.ts
@@ -16,6 +16,7 @@ export const urls = {
     },
     admin: {
       user: "/api/admin/user",
+      userVerified: "/api/admin/user/verified",
       animal: "/api/admin/animal",
       training: "/api/admin/training",
     },


### PR DESCRIPTION
## What is this?
Implements following functionality:
- admin get users (paginated using object ID)
- admin verify user

## Setup
- [x] No special setup needed

## Steps to Test
- [ ] Make GET request to /api/admin/user
  - Body example: { "afterId": "62fe7f95cca0bd0717ae0dff", "pageSize": 3 }
  - afterId field is optional
- [ ] Make PATCH request to /api/admin/user/verified
  - Body example: { "userId": "62fe7f95cca0bd0717ae0dff" }

## Associated Issues
Closes #27 

## Additional Info
I changed some file paths from those specified in the ticket to better follow the current convention (in my opinion). If you disagree with any of the decisions, please feel free to change them back 😎