### PR TITLE
Implement email verification endpoints

### DIFF
--- a/backend/server/mongodb/actions/User.ts
+++ b/backend/server/mongodb/actions/User.ts
@@ -81,3 +81,15 @@ export async function getUsers(pageSize: number, afterId?: Types.ObjectId) {
 
   return UserModel.find({ _id: { $gt: afterId } }).limit(pageSize);
 }
+
+export async function verifyUserEmail(userId: Types.ObjectId) {
+  await dbConnect();
+
+  const user = UserModel.findByIdAndUpdate(
+    userId,
+    { emailVerified: true },
+    { new: true }
+  );
+
+  return user;
+}

--- a/backend/server/mongodb/actions/VerificationLog.ts
+++ b/backend/server/mongodb/actions/VerificationLog.ts
@@ -1,0 +1,69 @@
+import { Types } from "mongoose";
+import UserModel from "server/mongodb/models/User";
+import VerificationLogModel from "server/mongodb/models/VerificationLog";
+import dbConnect from "server/utils/dbConnect";
+import { VERIFICATION_LOG_EXPIRATION_MINUTES } from "src/utils/constants";
+import { UserVerificationLogType } from "src/utils/types";
+
+export async function createVerificationLog(
+  userId: Types.ObjectId,
+  type: UserVerificationLogType
+) {
+  await dbConnect();
+
+  const user = await UserModel.findById(userId).exec();
+
+  if (user === null) {
+    throw new Error("User not found in database!");
+  }
+
+  const code = Math.floor(100000 + Math.random() * 900000);
+  const email = user.email;
+  const issueDate = new Date();
+  const expirationDate = new Date(
+    issueDate.getTime() + VERIFICATION_LOG_EXPIRATION_MINUTES * 60000
+  );
+
+  const verificationLog = await VerificationLogModel.create({
+    code,
+    user: userId,
+    email,
+    type,
+    issueDate,
+    expirationDate,
+    isVerified: false,
+    expired: false,
+  });
+
+  return verificationLog;
+}
+
+export async function updateVerificationLog(
+  id: Types.ObjectId,
+  isVerified?: boolean,
+  expired?: boolean
+) {
+  await dbConnect();
+
+  const verificationLog = await VerificationLogModel.findByIdAndUpdate(id, {
+    isVerified,
+    expired,
+  });
+
+  return verificationLog;
+}
+
+export async function getLatestVerificationLog(userId: Types.ObjectId) {
+  await dbConnect();
+
+  const logs = await VerificationLogModel.find({ user: userId }).exec();
+
+  let latestLog = undefined;
+  for (const log of logs) {
+    if (latestLog === undefined || log.issueDate > latestLog.issueDate) {
+      latestLog = log;
+    }
+  }
+
+  return latestLog;
+}

--- a/backend/server/mongodb/models/User.ts
+++ b/backend/server/mongodb/models/User.ts
@@ -45,6 +45,11 @@ const UserSchema = new mongoose.Schema<User>({
     type: String,
     required: false,
   },
+  emailVerified: {
+    type: Boolean,
+    required: true,
+    default: false,
+  },
 });
 
 const UserModel =

--- a/backend/server/mongodb/models/VerificationLog.ts
+++ b/backend/server/mongodb/models/VerificationLog.ts
@@ -1,0 +1,45 @@
+import mongoose, { Schema } from "mongoose";
+import { UserVerificationLogType, VerificationLog } from "src/utils/types";
+
+const VerificationLogSchema = new mongoose.Schema<VerificationLog>({
+  code: {
+    type: Number,
+    required: true,
+  },
+  user: {
+    type: Schema.Types.ObjectId,
+    required: true,
+    index: true,
+  },
+  email: {
+    type: String,
+    required: true,
+  },
+  type: {
+    type: String,
+    enum: UserVerificationLogType,
+    required: true,
+  },
+  issueDate: {
+    type: Date,
+    required: true,
+  },
+  expirationDate: {
+    type: Date,
+    required: true,
+  },
+  isVerified: {
+    type: Boolean,
+    required: true,
+  },
+  expired: {
+    type: Boolean,
+    required: true,
+  },
+});
+
+const VerificationLogModel =
+  (mongoose.models.VerificationLog as mongoose.Model<VerificationLog>) ||
+  mongoose.model<VerificationLog>("VerificationLog", VerificationLogSchema);
+
+export default VerificationLogModel;

--- a/backend/src/pages/api/auth/verify.ts
+++ b/backend/src/pages/api/auth/verify.ts
@@ -1,0 +1,73 @@
+import { Types } from "mongoose";
+import {
+  createVerificationLog,
+  getLatestVerificationLog,
+  updateVerificationLog,
+} from "server/mongodb/actions/VerificationLog";
+import APIWrapper from "server/utils/APIWrapper";
+import { sendEmail } from "server/utils/Authentication";
+import {
+  VERIFICATION_EMAIL_BODY,
+  VERIFICATION_EMAIL_SUBJECT,
+} from "src/utils/constants";
+import { UserVerificationLogType, VerificationLog } from "src/utils/types";
+
+export default APIWrapper({
+  POST: {
+    config: {
+      requireToken: false,
+    },
+    handler: async (req) => {
+      const userId: Types.ObjectId = req.body.userId as Types.ObjectId;
+      const type: UserVerificationLogType = req.body
+        .type as UserVerificationLogType;
+
+      const verificationLog = await createVerificationLog(userId, type);
+
+      if (!verificationLog) {
+        throw new Error("Failed to create verification log");
+      }
+
+      await sendEmail(
+        verificationLog.email,
+        VERIFICATION_EMAIL_SUBJECT,
+        VERIFICATION_EMAIL_BODY(verificationLog.code)
+      );
+
+      return verificationLog.expirationDate;
+    },
+  },
+  PATCH: {
+    config: {
+      requireToken: false,
+    },
+    handler: async (req) => {
+      const userId: Types.ObjectId = req.body.userId as Types.ObjectId;
+      const code = Number(req.body.code);
+
+      const latestLog: VerificationLog = (await getLatestVerificationLog(
+        userId
+      )) as VerificationLog;
+
+      if (!latestLog) {
+        throw new Error("User does not have any verification logs");
+      } else if (
+        latestLog.isVerified ||
+        latestLog.expired ||
+        new Date() > latestLog.expirationDate
+      ) {
+        await updateVerificationLog(latestLog._id, undefined, true);
+        throw new Error("Verification request has expired");
+      } else if (code !== latestLog.code) {
+        throw new Error("Incorrect code");
+      }
+
+      await updateVerificationLog(latestLog._id, true, true);
+
+      return {
+        userId,
+        authorized: true,
+      };
+    },
+  },
+});

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -1,0 +1,6 @@
+export const VERIFICATION_LOG_EXPIRATION_MINUTES = 60;
+
+export const VERIFICATION_EMAIL_SUBJECT =
+  "Verify your email for Healing4Heroes";
+export const VERIFICATION_EMAIL_BODY = (code: number) =>
+  `Verification code: ${code}`;

--- a/backend/src/utils/types.ts
+++ b/backend/src/utils/types.ts
@@ -25,6 +25,7 @@ export interface User {
   roles?: Array<Role>;
   profileImage?: string;
   verifiedByAdmin: boolean;
+  emailVerified: boolean;
 }
 
 export interface ServiceAnimal {
@@ -79,6 +80,23 @@ export enum ServiceAnimalSkills {
   SKILL_TOUCH = "Touch",
   SKILL_TUCK = "Tuck",
   SKILL_HEEL = "Heel",
+}
+
+export enum UserVerificationLogType {
+  EMAIL_VERIFICATION = "email verification",
+  PASSWORD_RESET = "password reset",
+}
+
+export interface VerificationLog {
+  _id: Types.ObjectId; // ObjectId of the Verification Log
+  code: number; // randomly generated 6-digit code the user receives in the email
+  user: Types.ObjectId; // _id of the user we sent the code to
+  email: string; // email the code is sent to
+  type: UserVerificationLogType; // two values (for now) --> UserVerificationLogType.EMAIL_VERIFICATION or UserVerificationLogType.PASSWORD_RESET
+  issueDate: Date; // the day and time the code was issued
+  expirationDate: Date; // The day and time the code expires (should always be 60 mins after the issueDate)
+  isVerified: boolean; // Used to indicate if the verification attempt succeeded (i.e. the user sent the right 6 digit code)
+  expired: boolean; // Used to indicate if the verification log has already been used / expired --> if so, it cannot be reused and the user must request a new one
 }
 
 /* Internal Request & API Wrapper Types */

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -512,14 +512,9 @@
   dependencies:
     "glob" "7.1.7"
 
-"@next/swc-linux-x64-gnu@12.2.4":
-  "integrity" "sha512-PhXX6NSuIuhHInxPY2VkG2Bl7VllsD3Cjx+pQcS1wTym7Zt7UoLvn05PkRrkiyIkvR+UXnqPUM3TYiSbnemXEw=="
-  "resolved" "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.4.tgz"
-  "version" "12.2.4"
-
-"@next/swc-linux-x64-musl@12.2.4":
-  "integrity" "sha512-GmC/QROiUZpFirHRfPQqMyCXZ+5+ndbBZrMvL74HtQB/CKXB8K1VM+rvy9Gp/5OaU8Rxp48IcX79NOfI2LiXlA=="
-  "resolved" "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.4.tgz"
+"@next/swc-darwin-x64@12.2.4":
+  "integrity" "sha512-IUlFMqeLjdIzDorrGC2Dt+2Ae3DbKQbRzCzmDq4/CP1+jJGeDXo/2AHnlE+WYnwQAC4KtAz6pbVnd3KstZWsVA=="
+  "resolved" "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.4.tgz"
   "version" "12.2.4"
 
 "@nodelib/fs.scandir@2.1.5":

--- a/mobile/actions/Auth.ts
+++ b/mobile/actions/Auth.ts
@@ -1,0 +1,30 @@
+import { urls } from "../utils/urls";
+import { Types } from "mongoose";
+import { HttpMethod, UserVerificationLogType } from "../utils/types";
+import { internalRequest } from "../utils/requests";
+
+const authVerifyUrl = urls.baseUrl + urls.api.auth.verify;
+
+export const authCreateVerificationLog = async (userId: Types.ObjectId, type: UserVerificationLogType) => {
+  return internalRequest<Date>({
+    url: authVerifyUrl,
+    method: HttpMethod.POST,
+    authRequired: false,
+    body: {
+      userId,
+      type,
+    }
+  })
+}
+
+export const authAttemptVerification = async (userId: Types.ObjectId, code: number) => {
+  return internalRequest<Date>({
+    url: authVerifyUrl,
+    method: HttpMethod.PATCH,
+    authRequired: false,
+    body: {
+      userId,
+      code,
+    }
+  })
+}

--- a/mobile/utils/types.ts
+++ b/mobile/utils/types.ts
@@ -39,6 +39,7 @@ export interface User {
   roles?: Array<Role>;
   profileImage?: string;
   verifiedByAdmin: boolean;
+  emailVerified: boolean;
 }
 
 export interface ServiceAnimal {
@@ -90,6 +91,12 @@ export interface UserContextType {
   user: User | null;
   animal: ServiceAnimal | null;
 }
+
+export enum UserVerificationLogType {
+  EMAIL_VERIFICATION = "email verification",
+  PASSWORD_RESET = "password reset",
+}
+
 /* Internal Request & API Wrapper Types */
 
 export enum HttpMethod {

--- a/mobile/utils/urls.ts
+++ b/mobile/utils/urls.ts
@@ -9,6 +9,9 @@ function getBaseURL() {
 export const urls = {
   baseUrl: getBaseURL(),
   api: {
+    auth: {
+      verify: "/api/auth/verify",
+    },
     user: {
       user: "/api/user/user",
       animal: "/api/user/animal",

--- a/mobile/yarn.lock
+++ b/mobile/yarn.lock
@@ -1482,9 +1482,9 @@
     "resolve-from" "^5.0.0"
     "sucrase" "^3.20.0"
 
-"@expo/ngrok-bin-linux-x64@2.3.40":
-  "integrity" "sha512-yOuwpOmMe6RGnk9ninlM7Zg1EiF81ptFOcFmT61PDOA4gK8/ttZKTMkDQiq0DZdcXUyE0HCr83EglJZTnHIzPA=="
-  "resolved" "https://registry.npmjs.org/@expo/ngrok-bin-linux-x64/-/ngrok-bin-linux-x64-2.3.40.tgz"
+"@expo/ngrok-bin-darwin-x64@2.3.40":
+  "integrity" "sha512-nqGLfxIjZBoT79VDk5mqaHQKCWkunSi486zGLeB8Ye8Qar1yo4STFwks+DqTbnGD5ItArQz2LzKRVE4YXuJFuw=="
+  "resolved" "https://registry.npmjs.org/@expo/ngrok-bin-darwin-x64/-/ngrok-bin-darwin-x64-2.3.40.tgz"
   "version" "2.3.40"
 
 "@expo/ngrok-bin@2.3.40":
@@ -3668,6 +3668,13 @@
   "integrity" "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
   "resolved" "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   "version" "2.2.0"
+
+"bindings@^1.5.0":
+  "integrity" "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="
+  "resolved" "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
+  "version" "1.5.0"
+  dependencies:
+    "file-uri-to-path" "1.0.0"
 
 "bl@^4.1.0":
   "integrity" "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="
@@ -6883,6 +6890,19 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
+"fsevents@^1.2.7":
+  "integrity" "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw=="
+  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz"
+  "version" "1.2.13"
+  dependencies:
+    "bindings" "^1.5.0"
+    "nan" "^2.12.1"
+
+"fsevents@^2.3.2", "fsevents@~2.3.2":
+  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
+  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  "version" "2.3.2"
+
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
   "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
@@ -9583,6 +9603,11 @@
     "any-promise" "^1.0.0"
     "object-assign" "^4.0.1"
     "thenify-all" "^1.0.0"
+
+"nan@^2.12.1":
+  "integrity" "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
+  "resolved" "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz"
+  "version" "2.16.0"
 
 "nanoid@^3.1.23":
   "integrity" "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="


### PR DESCRIPTION
## What is this?
Implements verification endpoints :D

## Setup
- [ ] No special setup needed

## Steps to Test
- [ ] create a verification log by POST request to endpoint `{{url}}/api/auth/verify`, body ```{
    "userId": "634ba585128c49a38499b547",
    "type": "email verification"
}```
- [ ] attempt verification by PATCH request to endpoint `{{url}}/api/auth/verify`, body ```{
    "userId": "634ba585128c49a38499b547",
    "code": "276756"
}```

## Associated Issues
closes #40 


## Additional Notes
The verification POST endpoint returns an error because the sendEmail call errors out. It works otherwise. I also just decided to make it return the expiration date of the verification endpoint, but this could be changed.