### PR TITLE
implement announcement read logs

### DIFF
--- a/backend/server/mongodb/actions/ReadLog.ts
+++ b/backend/server/mongodb/actions/ReadLog.ts
@@ -1,0 +1,44 @@
+import { Types } from "mongoose";
+import ReadLogModel from "server/mongodb/models/ReadLog";
+import dbConnect from "server/utils/dbConnect";
+
+export async function createReadLog(
+  announcement: Types.ObjectId,
+  user: Types.ObjectId,
+  date?: Date
+) {
+  await dbConnect();
+  const readLog = await ReadLogModel.create({
+    announcement,
+    user,
+    date,
+  });
+  return readLog;
+}
+
+export async function hasReadLog(
+  announcement: Types.ObjectId,
+  user: Types.ObjectId
+) {
+  await dbConnect();
+  const readLog = await ReadLogModel.find({
+    announcement: announcement,
+    user: user,
+  });
+
+  if (announcement) return true;
+  return false;
+}
+
+export async function getReadAnnouncements(user: Types.ObjectId) {
+  await dbConnect();
+  const readAnnouncements = await ReadLogModel.find(
+    { user: user },
+    {
+      announcement: 1,
+      _id: 0,
+    }
+  );
+
+  return readAnnouncements;
+}

--- a/backend/server/mongodb/models/ReadLog.ts
+++ b/backend/server/mongodb/models/ReadLog.ts
@@ -1,0 +1,24 @@
+import mongoose, { Schema } from "mongoose";
+import { ReadLog } from "src/utils/types";
+
+const ReadLogSchema = new mongoose.Schema<ReadLog>({
+  announcement: {
+    type: Schema.Types.ObjectId,
+    required: true,
+  },
+  user: {
+    type: Schema.Types.ObjectId,
+    required: true,
+  },
+  readAt: {
+    type: Date,
+    required: true,
+    default: Date.now(),
+  },
+});
+
+const ReadLogModel =
+  (mongoose.models.ReadLog as mongoose.Model<ReadLog>) ||
+  mongoose.model<ReadLog>("ReadLog", ReadLogSchema);
+
+export default ReadLogModel;

--- a/backend/src/pages/api/user/announcements/read.ts
+++ b/backend/src/pages/api/user/announcements/read.ts
@@ -1,0 +1,53 @@
+import { Types } from "mongoose";
+import {
+  createReadLog,
+  hasReadLog,
+  getReadAnnouncements,
+} from "server/mongodb/actions/ReadLog";
+import APIWrapper from "server/utils/APIWrapper";
+import { getUser } from "server/utils/Authentication";
+import { Role } from "src/utils/types";
+
+export default APIWrapper({
+  POST: {
+    config: {
+      requireToken: true,
+      roles: [Role.NONPROFIT_USER],
+    },
+    handler: async (req) => {
+      const accessToken: string = req.headers.accesstoken as string;
+      const user = await getUser(accessToken);
+
+      const announcement: Types.ObjectId = new Types.ObjectId(
+        req.body.announcement as string
+      );
+
+      const readLogExists = await hasReadLog(announcement, user._id);
+      if (readLogExists) return null;
+
+      const date: Date = req.body.date as Date;
+
+      const readLog = await createReadLog(announcement, user._id, date);
+
+      if (!readLog) {
+        throw new Error("Failed to create read log");
+      }
+
+      return readLog;
+    },
+  },
+  GET: {
+    config: {
+      requireToken: true,
+      roles: [Role.NONPROFIT_USER],
+    },
+    handler: async (req) => {
+      const accessToken: string = req.headers.accesstoken as string;
+      const user = await getUser(accessToken);
+
+      const readAnnouncements = await getReadAnnouncements(user._id);
+
+      return readAnnouncements;
+    },
+  },
+});

--- a/backend/src/utils/types.ts
+++ b/backend/src/utils/types.ts
@@ -67,6 +67,13 @@ export interface Announcement {
   sender: Types.ObjectId;
 }
 
+export interface ReadLog {
+  _id: Types.ObjectId;
+  announcement: Types.ObjectId;
+  user: Types.ObjectId;
+  readAt: Date;
+}
+
 export interface ServiceAnimalBehavior {
   description: string;
   repeat: number;

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -512,14 +512,9 @@
   dependencies:
     "glob" "7.1.7"
 
-"@next/swc-linux-x64-gnu@12.2.4":
-  "integrity" "sha512-PhXX6NSuIuhHInxPY2VkG2Bl7VllsD3Cjx+pQcS1wTym7Zt7UoLvn05PkRrkiyIkvR+UXnqPUM3TYiSbnemXEw=="
-  "resolved" "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.4.tgz"
-  "version" "12.2.4"
-
-"@next/swc-linux-x64-musl@12.2.4":
-  "integrity" "sha512-GmC/QROiUZpFirHRfPQqMyCXZ+5+ndbBZrMvL74HtQB/CKXB8K1VM+rvy9Gp/5OaU8Rxp48IcX79NOfI2LiXlA=="
-  "resolved" "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.4.tgz"
+"@next/swc-darwin-x64@12.2.4":
+  "integrity" "sha512-IUlFMqeLjdIzDorrGC2Dt+2Ae3DbKQbRzCzmDq4/CP1+jJGeDXo/2AHnlE+WYnwQAC4KtAz6pbVnd3KstZWsVA=="
+  "resolved" "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.4.tgz"
   "version" "12.2.4"
 
 "@nodelib/fs.scandir@2.1.5":

--- a/mobile/actions/ReadLog.ts
+++ b/mobile/actions/ReadLog.ts
@@ -1,0 +1,29 @@
+import { urls } from "../utils/urls";
+import { HttpMethod, ReadLog } from "../utils/types";
+import { internalRequest } from "../utils/requests";
+import { Types } from "mongoose";
+
+const userReadLogUrl = urls.baseUrl + urls.api.user.readLog;
+
+export const userCreateReadLog = async (
+  announcement: Types.ObjectId,
+  date?: Date
+) => {
+  return internalRequest<ReadLog>({
+    url: userReadLogUrl,
+    method: HttpMethod.POST,
+    authRequired: true,
+    body: {
+      announcement,
+      date,
+    },
+  });
+};
+
+export const userGetReadAnnouncements = async () => {
+  return internalRequest<Array<Types.ObjectId>>({
+    url: userReadLogUrl,
+    method: HttpMethod.GET,
+    authRequired: true,
+  });
+};

--- a/mobile/utils/types.ts
+++ b/mobile/utils/types.ts
@@ -81,6 +81,13 @@ export interface Announcement {
   sender: Types.ObjectId;
 }
 
+export interface ReadLog {
+  _id: Types.ObjectId;
+  announcement: Types.ObjectId;
+  user: Types.ObjectId;
+  readAt: Date;
+}
+
 export interface ServiceAnimalBehavior {
   description: string;
   repeat: number;

--- a/mobile/utils/urls.ts
+++ b/mobile/utils/urls.ts
@@ -13,13 +13,15 @@ export const urls = {
       user: "/api/user/user",
       animal: "/api/user/animal",
       training: "/api/user/training",
-      announcement: "api/user/announcement",
+      announcement: "/api/user/announcement",
+      readLog: "/api/user/announcements/read",
     },
     admin: {
       user: "/api/admin/user",
       userVerified: "/api/admin/user/verified",
       animal: "/api/admin/animal",
-      announcement: "api/admin/announcement",
+      training: "/api/admin/training",
+      announcement: "/api/admin/announcement",
     },
   },
 };

--- a/mobile/yarn.lock
+++ b/mobile/yarn.lock
@@ -1482,9 +1482,9 @@
     "resolve-from" "^5.0.0"
     "sucrase" "^3.20.0"
 
-"@expo/ngrok-bin-linux-x64@2.3.40":
-  "integrity" "sha512-yOuwpOmMe6RGnk9ninlM7Zg1EiF81ptFOcFmT61PDOA4gK8/ttZKTMkDQiq0DZdcXUyE0HCr83EglJZTnHIzPA=="
-  "resolved" "https://registry.npmjs.org/@expo/ngrok-bin-linux-x64/-/ngrok-bin-linux-x64-2.3.40.tgz"
+"@expo/ngrok-bin-darwin-x64@2.3.40":
+  "integrity" "sha512-nqGLfxIjZBoT79VDk5mqaHQKCWkunSi486zGLeB8Ye8Qar1yo4STFwks+DqTbnGD5ItArQz2LzKRVE4YXuJFuw=="
+  "resolved" "https://registry.npmjs.org/@expo/ngrok-bin-darwin-x64/-/ngrok-bin-darwin-x64-2.3.40.tgz"
   "version" "2.3.40"
 
 "@expo/ngrok-bin@2.3.40":
@@ -3668,6 +3668,13 @@
   "integrity" "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
   "resolved" "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   "version" "2.2.0"
+
+"bindings@^1.5.0":
+  "integrity" "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="
+  "resolved" "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
+  "version" "1.5.0"
+  dependencies:
+    "file-uri-to-path" "1.0.0"
 
 "bl@^4.1.0":
   "integrity" "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="
@@ -6883,6 +6890,19 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
+"fsevents@^1.2.7":
+  "integrity" "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw=="
+  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz"
+  "version" "1.2.13"
+  dependencies:
+    "bindings" "^1.5.0"
+    "nan" "^2.12.1"
+
+"fsevents@^2.3.2", "fsevents@~2.3.2":
+  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
+  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  "version" "2.3.2"
+
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
   "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
@@ -9583,6 +9603,11 @@
     "any-promise" "^1.0.0"
     "object-assign" "^4.0.1"
     "thenify-all" "^1.0.0"
+
+"nan@^2.12.1":
+  "integrity" "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
+  "resolved" "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz"
+  "version" "2.16.0"
 
 "nanoid@^3.1.23":
   "integrity" "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="


### PR DESCRIPTION
## What is this?
<!-- Brief description of additions -->
Implement the create and get functionalities of announcement read logs

Note: only one document of an <announcement, user> pair will be created. This means that the backend will only save the first time the user reads the announcement (and none after) to avoid duplications. Let me know if you'd like to remove this.

## Setup
<!-- What needs to be run or setup for testing -->

- [X] No special setup needed

## Steps to Test
<!-- What are the steps to test these additions -->

Connect to database
Make a POST request to http://localhost:3000/api/user/announcements/read with the following body to test the create function:
```
{
    "announcement": <string id of announcement>,
    "date": <date, optional>
}
```

Make a GET request to http://localhost:3000/api/user/announcements/read to test the get function

## Associated Issues
<!-- Which issues do these additions close (phrase as "closes #") -->
#38


## Additional Instructions
<!-- State any additional details here if necessary -->



<!--
  Ensure your branch is not behind main and click preview to check formatting before submitting pull request
-->
