### PR TITLE
return total user count

### DIFF
--- a/backend/server/mongodb/actions/TrainingLog.ts
+++ b/backend/server/mongodb/actions/TrainingLog.ts
@@ -33,7 +33,9 @@ export async function createTrainingLog(
 
 export async function getTrainingLogs(userId: Types.ObjectId | string) {
   await dbConnect();
-  const trainingLogs = await TrainingLogModel.find({ handler: userId }).sort({ date: -1 });
+  const trainingLogs = await TrainingLogModel.find({ handler: userId }).sort({
+    date: -1,
+  });
   return trainingLogs;
 }
 

--- a/backend/server/mongodb/actions/User.ts
+++ b/backend/server/mongodb/actions/User.ts
@@ -1,8 +1,8 @@
-import { Types } from 'mongoose';
-import AnimalModel from 'server/mongodb/models/Animal';
-import UserModel from 'server/mongodb/models/User';
-import dbConnect from 'server/utils/dbConnect';
-import { HandlerType, Role, UserFilter } from 'src/utils/types';
+import { Types } from "mongoose";
+import AnimalModel from "server/mongodb/models/Animal";
+import UserModel from "server/mongodb/models/User";
+import dbConnect from "server/utils/dbConnect";
+import { HandlerType, Role, UserFilter } from "src/utils/types";
 
 export async function findUserById(userId: Types.ObjectId | string) {
   await dbConnect();
@@ -90,14 +90,14 @@ export async function adminGetUsers(
   searchText?: string
 ) {
   await dbConnect();
-  searchText = searchText ? '^' + searchText + '(.*)' : searchText;
+  searchText = searchText ? "^" + searchText + "(.*)" : searchText;
   const searchQuery = {
     ...(afterId && { _id: { $gt: afterId } }),
     ...(searchText && {
       $or: [
-        { email: { $regex: searchText, $options: 'i' } },
-        { firstName: { $regex: searchText, $options: 'i' } },
-        { lastName: { $regex: searchText, $options: 'i' } },
+        { email: { $regex: searchText, $options: "i" } },
+        { firstName: { $regex: searchText, $options: "i" } },
+        { lastName: { $regex: searchText, $options: "i" } },
       ],
     }),
   };
@@ -117,7 +117,7 @@ export async function adminGetUsers(
   } else if (filter === UserFilter.WITH_800_HOURS_USERS) {
     const handlers = await AnimalModel.find({
       totalHours: { $gte: 800 },
-    }).select('handler');
+    }).select("handler");
 
     query = {
       _id: {
@@ -128,7 +128,7 @@ export async function adminGetUsers(
   } else if (filter === UserFilter.WITHOUT_800_HOURS_USERS) {
     const handlers = await AnimalModel.find({
       totalHours: { $gte: 800 },
-    }).select('handler');
+    }).select("handler");
 
     query = {
       _id: {

--- a/backend/server/mongodb/actions/User.ts
+++ b/backend/server/mongodb/actions/User.ts
@@ -102,52 +102,54 @@ export async function adminGetUsers(
     }),
   };
 
-  let query: any;
-
   if (!filter || filter === UserFilter.NONPROFIT_USERS) {
-    query = {
+    return UserModel.find({
       ...searchQuery,
       roles: { $nin: [Role.NONPROFIT_ADMIN] },
-    };
-  } else if (filter === UserFilter.UNVERIFIED_USERS) {
-    query = {
-      ...searchQuery,
-      verifiedByAdmin: false,
-    };
-  } else if (filter === UserFilter.WITH_800_HOURS_USERS) {
+    }).limit(pageSize);
+  }
+
+  if (filter === UserFilter.UNVERIFIED_USERS) {
+    return UserModel.find({ ...searchQuery, verifiedByAdmin: false }).limit(
+      pageSize
+    );
+  }
+
+  // Hours is on the Animal, not the users
+  if (filter === UserFilter.WITH_800_HOURS_USERS) {
     const handlers = await AnimalModel.find({
       totalHours: { $gte: 800 },
     }).select("handler");
 
-    query = {
+    return UserModel.find({
       _id: {
         ...(afterId && { $gt: afterId }),
         $in: handlers.map((item) => item.handler),
       },
-    };
-  } else if (filter === UserFilter.WITHOUT_800_HOURS_USERS) {
+    }).limit(pageSize);
+  }
+
+  if (filter === UserFilter.WITHOUT_800_HOURS_USERS) {
     const handlers = await AnimalModel.find({
       totalHours: { $gte: 800 },
     }).select("handler");
 
-    query = {
+    return UserModel.find({
       _id: {
         ...(afterId && { $gt: afterId }),
+        // some verified users do not have an animal
         $nin: handlers.map((item) => item.handler),
       },
       verifiedByAdmin: true,
-    };
-  } else if (filter === UserFilter.NONPROFIT_ADMINS) {
-    query = {
-      ...searchQuery,
-      roles: { $in: [Role.NONPROFIT_ADMIN] },
-    };
+    }).limit(pageSize);
   }
 
-  const users = await UserModel.find(query).limit(pageSize);
-  const totalCount = await UserModel.countDocuments(query);
-
-  return { users, totalCount };
+  if (filter === UserFilter.NONPROFIT_ADMINS) {
+    return UserModel.find({
+      ...searchQuery,
+      roles: { $in: [Role.NONPROFIT_ADMIN] },
+    }).limit(pageSize);
+  }
 }
 
 export async function verifyUserEmail(userId: Types.ObjectId) {

--- a/backend/src/pages/api/admin/user.ts
+++ b/backend/src/pages/api/admin/user.ts
@@ -1,7 +1,7 @@
-import { Types } from 'mongoose';
-import { adminGetUsers } from 'server/mongodb/actions/User';
-import APIWrapper from 'server/utils/APIWrapper';
-import { Role, UserFilter } from 'src/utils/types';
+import { Types } from "mongoose";
+import { adminGetUsers } from "server/mongodb/actions/User";
+import APIWrapper from "server/utils/APIWrapper";
+import { Role, UserFilter } from "src/utils/types";
 
 export default APIWrapper({
   POST: {

--- a/backend/src/pages/api/admin/user.ts
+++ b/backend/src/pages/api/admin/user.ts
@@ -19,17 +19,9 @@ export default APIWrapper({
         | undefined;
       const searchText: string = req.body.searchText as string;
 
-      const { users, totalCount } = await adminGetUsers(
-        pageSize,
-        afterId,
-        filter,
-        searchText
-      );
+      const users = await adminGetUsers(pageSize, afterId, filter, searchText);
 
-      return {
-        users,
-        totalCount,
-      };
+      return users;
     },
   },
 });

--- a/backend/src/pages/api/admin/user.ts
+++ b/backend/src/pages/api/admin/user.ts
@@ -1,7 +1,7 @@
-import { Types } from "mongoose";
-import { adminGetUsers } from "server/mongodb/actions/User";
-import APIWrapper from "server/utils/APIWrapper";
-import { Role, UserFilter } from "src/utils/types";
+import { Types } from 'mongoose';
+import { adminGetUsers } from 'server/mongodb/actions/User';
+import APIWrapper from 'server/utils/APIWrapper';
+import { Role, UserFilter } from 'src/utils/types';
 
 export default APIWrapper({
   POST: {
@@ -19,9 +19,17 @@ export default APIWrapper({
         | undefined;
       const searchText: string = req.body.searchText as string;
 
-      const users = await adminGetUsers(pageSize, afterId, filter, searchText);
+      const { users, totalCount } = await adminGetUsers(
+        pageSize,
+        afterId,
+        filter,
+        searchText
+      );
 
-      return users;
+      return {
+        users,
+        totalCount,
+      };
     },
   },
 });

--- a/backend/src/pages/api/admin/user.ts
+++ b/backend/src/pages/api/admin/user.ts
@@ -19,9 +19,17 @@ export default APIWrapper({
         | undefined;
       const searchText: string = req.body.searchText as string;
 
-      const users = await adminGetUsers(pageSize, afterId, filter, searchText);
+      const { users, totalCount } = await adminGetUsers(
+        pageSize,
+        afterId,
+        filter,
+        searchText
+      );
 
-      return users;
+      return {
+        users,
+        totalCount,
+      };
     },
   },
 });


### PR DESCRIPTION
## What is this?
<!-- Brief description of additions -->
- [ ] Update `backend/src/pages/api/admin/user.ts` so that the returned data is in the format of
```
{
   users: Users[],
   total: number
}
```
where total is the count of the total number of users
- [ ]  Make sure that the total is calculated using the filters applied to the request

## Setup
<!-- What needs to be run or setup for testing -->
- added frontend testing code in AdminUserListScreen, should delete before merging 

## Steps to Test
<!-- What are the steps to test these additions -->
1. Generate Admin User Token 
2. Navigate to Admin Dashboard & check each user list to see total # of users for each filter 

## Associated Issues
<!-- Which issues do these additions close (phrase as "closes #") -->

closes #129 

## Additional Instructions
<!-- State any additional details here if necessary -->




<!--
  Ensure your branch is not behind main and click preview to check formatting before submitting pull request
-->
